### PR TITLE
Fix NoReverseMatch for order detail URL

### DIFF
--- a/skyhigh/core/urls/__init__.py
+++ b/skyhigh/core/urls/__init__.py
@@ -1,5 +1,6 @@
 from django.urls import path, include
 from core.views import base, about, contact, brands
+from core.views.orders import order_detail_view
 app_name = "core"
 
 urlpatterns = [
@@ -9,4 +10,6 @@ urlpatterns = [
     path('brands/', brands.brand_index, name='brand-index'),
     path('brands/<slug:slug>/', brands.brand_detail, name='brand-detail'),
     path("auth/", include("core.urls.auth", namespace="auth")),
+    # Order detail page for users to view a single order
+    path('orders/<int:order_id>/', order_detail_view, name='order_detail'),
 ]


### PR DESCRIPTION
## Summary
- include the order detail view in the core URL patterns

## Testing
- `pytest -q`
- `python skyhigh/manage.py show_urls | grep order`


------
https://chatgpt.com/codex/tasks/task_e_68502fff35c88325900dbf39985a842e