### PR TITLE
Fix privacy policy routing

### DIFF
--- a/skyhigh/core/urls/__init__.py
+++ b/skyhigh/core/urls/__init__.py
@@ -1,6 +1,7 @@
 from django.urls import path, include
 from core.views import base, about, contact, brands
 from core.views.orders import order_detail_view
+from core.views.static_pages import privacy_policy_view, terms_and_conditions_view
 app_name = "core"
 
 urlpatterns = [
@@ -12,4 +13,6 @@ urlpatterns = [
     path("auth/", include("core.urls.auth", namespace="auth")),
     # Order detail page for users to view a single order
     path('orders/<int:order_id>/', order_detail_view, name='order_detail'),
+    path("privacy-policy/", privacy_policy_view, name="privacy_policy"),
+    path("terms-and-conditions/", terms_and_conditions_view, name="terms_and_conditions"),
 ]


### PR DESCRIPTION
## Summary
- add missing import for privacy pages
- register `privacy-policy` and `terms-and-conditions` routes

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68503eb568e8832587acdd33c1c70d2e