### PR TITLE
Center search bar below header

### DIFF
--- a/skyhigh/core/templates/core/header.html
+++ b/skyhigh/core/templates/core/header.html
@@ -47,30 +47,17 @@
 
       <!-- Right Icons -->
       <div class="flex items-center gap-6 sm:gap-8 text-sm font-medium text-gray-700 relative z-50"
-           x-data="{ count: {{ cart_item_count|default:0 }}, activeDropdown: null, showSearch: false }"
+           x-data="{ count: {{ cart_item_count|default:0 }}, activeDropdown: null }"
            x-init="window.addEventListener('cart-updated', e => count = e.detail.count)">
 
         <!-- Search Icon and Floating Bar -->
-        <div class="relative"
-             @mouseenter="showSearch = true; activeDropdown = null"
-             @mouseleave="showSearch = false">
-          <button class="hover:text-red-600 focus:outline-none" aria-label="Search Products">
+        <div class="relative">
+          <button @click="showSearch = !showSearch; activeDropdown = null"
+                  class="hover:text-red-600 focus:outline-none" aria-label="Search Products">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M10 18a8 8 0 100-16 8 8 0 000 16z"/>
             </svg>
           </button>
-
-          <div x-show="showSearch"
-               x-transition:enter="transition ease-out duration-300"
-               x-transition:enter-start="opacity-0 -translate-y-2"
-               x-transition:enter-end="opacity-100 translate-y-0"
-               x-transition:leave="transition ease-in duration-200"
-               x-transition:leave-start="opacity-100 translate-y-0"
-               x-transition:leave-end="opacity-0 -translate-y-2"
-               class="absolute top-[2.5rem] left-1/2 transform -translate-x-1/2 z-50 w-screen max-w-2xl"
-               x-cloak>
-            {% include "core/search_input.html" %}
-          </div>
         </div>
 
         <!-- Cart Icon with Dropdown -->


### PR DESCRIPTION
## Summary
- toggle `showSearch` on click from search icon
- remove the old floating bar next to the icon
- rely on existing centered search bar under the header

## Testing
- `python skyhigh/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685417b3cd30832581ad5ef1b5055088