### PR TITLE
Center header logo

### DIFF
--- a/skyhigh/core/templates/core/header.html
+++ b/skyhigh/core/templates/core/header.html
@@ -27,7 +27,7 @@
         class="bg-white border-b border-gray-200 sticky top-0 z-50 transition-transform duration-300">
 
   <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-4 relative">
-    <div class="flex items-center justify-between">
+    <div class="flex items-center justify-between relative">
       <!-- Sidebar Toggle -->
       <div class="relative z-50">
         <button @mouseenter="open = true" class="text-gray-700 hover:text-red-600 focus:outline-none" aria-label="Toggle Sidebar">
@@ -38,12 +38,10 @@
       </div>
 
       <!-- Logo -->
-      <div class="flex-1 flex justify-center sm:justify-center">
-        <a href="/" class="flex items-center space-x-2">
-          <img src="{% static 'images/logo.jpg' %}" alt="Sky High Logo" class="h-10 w-auto sm:h-12" />
-          <span class="text-2xl sm:text-3xl font-extrabold text-red-600 whitespace-nowrap sky-font">SKY HIGH</span>
-        </a>
-      </div>
+      <a href="/" class="absolute left-1/2 transform -translate-x-1/2 flex items-center space-x-2">
+        <img src="{% static 'images/logo.jpg' %}" alt="Sky High Logo" class="h-10 w-auto sm:h-12" />
+        <span class="text-2xl sm:text-3xl font-extrabold text-red-600 whitespace-nowrap sky-font">SKY HIGH</span>
+      </a>
 
       <!-- Right Icons -->
       <div class="flex items-center gap-6 sm:gap-8 text-sm font-medium text-gray-700 relative z-50"

--- a/skyhigh/core/templates/core/product_search_bar.html
+++ b/skyhigh/core/templates/core/product_search_bar.html
@@ -26,7 +26,7 @@
         class="bg-white border-b border-gray-200 sticky top-0 z-50 transition-transform duration-300">
 
   <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-4 relative">
-    <div class="flex items-center justify-between">
+    <div class="flex items-center justify-between relative">
 
       <!-- Sidebar Toggle -->
       <div class="relative z-50">
@@ -49,12 +49,10 @@
       </div>
 
       <!-- Logo -->
-      <div class="flex-1 flex justify-center sm:justify-center">
-        <a href="/" class="flex items-center space-x-2">
-          <img src="{% static 'images/logo.jpg' %}" alt="Sky High Logo" class="h-10 w-auto sm:h-12" />
-          <span class="text-2xl sm:text-3xl font-extrabold text-red-600 whitespace-nowrap sky-font">SKY HIGH</span>
-        </a>
-      </div>
+      <a href="/" class="absolute left-1/2 transform -translate-x-1/2 flex items-center space-x-2">
+        <img src="{% static 'images/logo.jpg' %}" alt="Sky High Logo" class="h-10 w-auto sm:h-12" />
+        <span class="text-2xl sm:text-3xl font-extrabold text-red-600 whitespace-nowrap sky-font">SKY HIGH</span>
+      </a>
 
       <!-- Right Icons -->
       <div class="flex items-center space-x-4 text-sm font-medium text-gray-700 relative z-40"

--- a/skyhigh/core/templates/header.html
+++ b/skyhigh/core/templates/header.html
@@ -31,7 +31,7 @@
     class="bg-white border-b border-gray-200 sticky top-0 z-50 transition-transform duration-300">
 
     <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-4 relative">
-      <div class="flex items-center justify-between">
+      <div class="flex items-center justify-between relative">
 
         <!-- Sidebar Toggle -->
         <div class="relative z-50">
@@ -43,12 +43,10 @@
         </div>
 
         <!-- Logo -->
-        <div class="flex-1 flex justify-center sm:justify-center">
-          <a href="/" class="flex items-center space-x-2">
-            <img src="{% static 'images/logo.jpg' %}" alt="Sky High Logo" class="h-10 w-auto sm:h-12" />
-            <span class="text-2xl sm:text-3xl font-extrabold text-red-600 whitespace-nowrap sky-font">SKY HIGH</span>
-          </a>
-        </div>
+        <a href="/" class="absolute left-1/2 transform -translate-x-1/2 flex items-center space-x-2">
+          <img src="{% static 'images/logo.jpg' %}" alt="Sky High Logo" class="h-10 w-auto sm:h-12" />
+          <span class="text-2xl sm:text-3xl font-extrabold text-red-600 whitespace-nowrap sky-font">SKY HIGH</span>
+        </a>
 
         <!-- Right Icons -->
         <div class="flex items-center gap-6 sm:gap-8 text-sm font-medium text-gray-700 relative z-50">


### PR DESCRIPTION
## Summary
- keep logo centered inside header

## Testing
- `python skyhigh/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6854254bfc488325845a8c73c5ec52e2