### PR TITLE
Fix search bar accessibility

### DIFF
--- a/skyhigh/core/templates/core/header.html
+++ b/skyhigh/core/templates/core/header.html
@@ -33,6 +33,14 @@ x-init="
       showSearch = false;
     }
   });
+
+  $watch('showSearch', value => {
+    if (value) {
+      $nextTick(() => {
+        $refs.searchInput && $refs.searchInput.focus();
+      });
+    }
+  });
 "
 
 
@@ -93,7 +101,9 @@ x-init="
             <button x-show="!showSearch"
                     x-transition
                     class="hover:text-red-600 focus:outline-none"
-                    aria-label="Search Products">
+                    aria-label="Search Products"
+                    @click="showSearch = true"
+                    @focus="showSearch = true">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                       d="M21 21l-4.35-4.35M10 18a8 8 0 100-16 8 8 0 000 16z"/>

--- a/skyhigh/core/templates/core/search_input.html
+++ b/skyhigh/core/templates/core/search_input.html
@@ -4,6 +4,7 @@
   
   <!-- Search Input -->
   <input
+    x-ref="searchInput"
     type="text"
     name="q"
     x-model="query"


### PR DESCRIPTION
## Summary
- auto-focus search input when search bar opens
- allow clicking or focusing on search icon to open search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546f7b68e0832593e9666c9b7dfecf