### PR TITLE
Improve search bar focus

### DIFF
--- a/skyhigh/core/templates/core/header.html
+++ b/skyhigh/core/templates/core/header.html
@@ -37,7 +37,7 @@ x-init="
   $watch('showSearch', value => {
     if (value) {
       $nextTick(() => {
-        $refs.searchInput && $refs.searchInput.focus();
+        window.dispatchEvent(new Event('search-open'));
       });
     }
   });
@@ -72,7 +72,7 @@ x-init="
 
 
       <!-- Floating Search Bar (centered over logo) -->
-      <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-2xl px-6 pointer-events-auto"
+      <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-60 w-full max-w-2xl px-6 pointer-events-auto"
           x-show="showSearch"
           @click.outside="showSearch = false"
           x-transition:enter="transition ease-out duration-300"

--- a/skyhigh/core/templates/core/search_input.html
+++ b/skyhigh/core/templates/core/search_input.html
@@ -1,5 +1,6 @@
 <form action="{% url 'products:search' %}" method="get"
       x-data="liveSearch()" @keydown.escape="clearAll" @click.outside="clearSuggestions"
+      x-on:search-open.window="$nextTick(() => $refs.searchInput.focus())"
       class="relative w-full max-w-2xl mx-auto">
   
   <!-- Search Input -->


### PR DESCRIPTION
## Summary
- fire a `search-open` event on showSearch change
- ensure floating search bar stays above header with a higher z-index
- focus search input when `search-open` occurs

## Testing
- `python3 skyhigh/manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_685472ac8cd88325a9e4ce2c235e28f6