### PR TITLE
Fix cart dropdown after adding item

### DIFF
--- a/skyhigh/core/templates/core/header.html
+++ b/skyhigh/core/templates/core/header.html
@@ -169,9 +169,8 @@ x-init="
                     window.dispatchEvent(new CustomEvent('cart-updated', { detail: { count: data.count } }));
                   });
                 }
-     }"
-
-               }"
+              }"
+              x-init="window.addEventListener('cart-item-added', e => { const item = e.detail; const existing = items.find(i => i.id === item.id); if (existing) { existing.quantity += 1; } else { items.push({ id: item.id, name: item.name, price: item.price, quantity: 1, image: item.image }); } });"
                x-transition:enter="transition ease-out duration-200"
                x-transition:enter-start="opacity-0 -translate-y-1"
                x-transition:enter-end="opacity-100 translate-y-0"

--- a/skyhigh/core/templates/core/product_detail.html
+++ b/skyhigh/core/templates/core/product_detail.html
@@ -48,6 +48,13 @@
 
 <!-- AJAX Script for Add to Cart -->
 <script>
+  const currentProduct = {
+    id: {{ product.id }},
+    name: '{{ product.name|escapejs }}',
+    price: {{ product.price }},
+    image: '{% static "images/" %}{{ image_folder }}/{{ product.image }}'
+  };
+
   function addToCart(productId) {
     fetch(`/cart/add/${productId}/`, {
       method: 'POST',
@@ -64,6 +71,7 @@
         window.dispatchEvent(new CustomEvent('cart-updated', {
           detail: { count: data.cart_count }
         }));
+        window.dispatchEvent(new CustomEvent('cart-item-added', { detail: currentProduct }));
         alert("✅ Added to cart!");
       } else {
         alert("❌ Could not add to cart.");


### PR DESCRIPTION
## Summary
- update product detail JS to send details of added item
- update header dropdown to listen for `cart-item-added` and update items list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a7202ef48325afd96218ed478f06